### PR TITLE
Fix expired token issue from ms graph

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 
 import './App.css'
-
+import { useEffect } from 'react'
 import { Users } from './views/Users'
 import { Landing } from './views/Landing'
 import { Groups } from './views/Groups'
@@ -17,8 +17,12 @@ import Admin from './views/Admin'
 import SignUp from './views/Signup'
 import { AuthContextProvider } from './contexts/Auth'
 import ProtectedRoute from './components/shared/ProtectedRoute'
+import { fetchWrapper } from './utils/fetch'
 
 export default function App() {
+    useEffect(() => {
+        window.fetch = fetchWrapper(window.fetch)
+    }, [])
     return (
         <AuthContextProvider>
             <Router>

--- a/client/src/services/base.ts
+++ b/client/src/services/base.ts
@@ -3,20 +3,14 @@ import { Client } from '@microsoft/microsoft-graph-client'
 
 export class BaseService {
     protected static async httpGet(url: string) {
-        const token = await TokenService.getToken()
-        return fetch(url, {
-            method: 'GET',
-            headers: {
-                Authorization: `Bearer ${token}`,
-                ConsistencyLevel: 'eventual',
-            },
-        }).then(response => response.json())
+        return fetch(url).then(response => response.json())
     }
 }
 
 export const graphClient = Client.init({
     // For supporting beta version
     defaultVersion: 'beta',
+
     authProvider: async done => {
         const accessToken = await TokenService.getToken()
         done(null, accessToken)

--- a/client/src/utils/fetch.ts
+++ b/client/src/utils/fetch.ts
@@ -1,0 +1,15 @@
+export const fetchWrapper = (originalFetch: any) => (input: RequestInfo | URL, init?: RequestInit | undefined) => {
+    if (input.toString().startsWith('https://graph.microsoft.com')) {
+        return originalFetch('/ms-graph-proxy', {
+            method: 'POST',
+            body: JSON.stringify({
+                url: input,
+            }),
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        })
+    } else {
+        return originalFetch(input, init)
+    }
+}

--- a/server/dto/auth.dto.ts
+++ b/server/dto/auth.dto.ts
@@ -9,3 +9,7 @@ export class SignupDto {
     firstName: string
     lastName: string
 }
+
+export class MsGraphProxy {
+    url: string
+}

--- a/server/middleware/token.middleware.ts
+++ b/server/middleware/token.middleware.ts
@@ -3,10 +3,14 @@ import { Request, Response, NextFunction } from 'express'
 import { jwtDecode } from 'jwt-decode'
 import { fetchToken } from '../utils/token'
 
+interface RequestWithToken extends Request {
+    token?: string
+}
 @Injectable()
 export class TokenMiddleware implements NestMiddleware {
-    async use(req: Request, res: Response, next: NextFunction) {
+    async use(req: RequestWithToken, res: Response, next: NextFunction) {
         const accessToken = req.cookies['access_token']
+        req.token = accessToken
         if (accessToken) {
             try {
                 const decodedToken = jwtDecode(accessToken)
@@ -20,6 +24,7 @@ export class TokenMiddleware implements NestMiddleware {
                         httpOnly: true,
                         secure: process.env.NODE_ENV === 'production',
                     })
+                    req.token = data.access_token
                 }
             } catch (err) {
                 console.log('err while reading token is', err)

--- a/server/modules/app.module.ts
+++ b/server/modules/app.module.ts
@@ -2,11 +2,12 @@ import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common'
 import { AppController } from '../controllers/app.controller'
 import { AppService } from '../services/app.service'
 import { TokenMiddleware } from '../middleware/token.middleware'
+import { MsGraphBaseService } from '../services/msgraph-base.service'
 
 @Module({
     imports: [],
     controllers: [AppController],
-    providers: [AppService],
+    providers: [AppService, MsGraphBaseService],
 })
 export class AppModule implements NestModule {
     configure(consumer: MiddlewareConsumer) {

--- a/server/services/msgraph-base.service.ts
+++ b/server/services/msgraph-base.service.ts
@@ -1,0 +1,13 @@
+import axios from 'axios'
+
+export class MsGraphBaseService {
+    async httpGet(url: string, token: string) {
+        const response = await axios.get(url, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                ConsistencyLevel: 'eventual',
+            },
+        })
+        return response.data
+    }
+}


### PR DESCRIPTION
@adbahrani I found a bug while testing a logged in session overnight, i think the refresh token was not happening on client side because we refresh token when our api gets called.

So the scenario where refresh token would not happen is call /users which directly calls msgaph api, to fix this issue.

I [created](https://github.com/adbahrani/MSGraphDashBoard/pull/27/commits/650d2f020c0655b1c32e96f13ca54a7f4bc68510):

- Attach the token req.token in middleware
- Create a proxy endpoint which forwards request to msgraph api through our api
- Write a wrapper for window.fetch
- This wrapper checks if url starts with https://graph.microsoft.com
- If yes then forward the request with msgraph url to /msgraph-proxy
- Return the result and render on client side

One more advantage of this is, now client side do not need to expose the token in requests.

But this is a sub-optimal approach as it makes hits on our server, especially in parallel call cases.

The long term approach i can suggest is to move all the client/services in backend and move all logic in backend

That would improve performance and makes the app scalable :)